### PR TITLE
🔧 Update min_version format

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "An elegant open-source and mobile-first theme"
 homepage = "https://html5up.net/uploads/demos/dopetrope/index.html"
 tags = ["blog", "html5up"]
 features = ["blog"]
-min_version = 0.94
+min_version = "0.94.2"
 
 [author]
     name = "Curtis Timson"


### PR DESCRIPTION
Update `min_version` from `0.94` to `"0.94.2"` to match standards set in Hugo docs.